### PR TITLE
Potential fix for code scanning alert no. 3: Disabling certificate validation

### DIFF
--- a/front/src/lib/authOptions.ts
+++ b/front/src/lib/authOptions.ts
@@ -42,16 +42,16 @@ export const authOptions: AuthOptions = {
       },
       async authorize(credentials) {
         try {
-          const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+          
 
           const response = await axios.post<BackendUser>(
             `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
             {
               email: credentials?.email,
               senha: credentials?.password
-            },
-            { httpsAgent }
+            }
           );
+
 
           const user = response.data;
           const userRole = user.role.toLowerCase();


### PR DESCRIPTION
Potential fix for [https://github.com/ifpebj-ti/horas-discentes/security/code-scanning/3](https://github.com/ifpebj-ti/horas-discentes/security/code-scanning/3)

To fix the problem, you should not disable certificate validation by setting `rejectUnauthorized: false` in the `https.Agent`. The best approach is to simply remove the custom `https.Agent` with `rejectUnauthorized: false` and allow HTTPS requests to use Node's default agent, which performs certificate validation correctly. This fix ensures secure handling of HTTPS requests to the backend server and preserves current functionality, except that now only legitimate, trusted servers are connected to. If you do need to allow test self-signed certificates in non-production environments, include a check to ensure this is only done for local development and never in production.

In this case, since there is no such environment check, the single best way to fix is to delete or comment out the creation and use of the custom `https.Agent` and allow Axios to use the default agent.

Remove or comment out:

```ts
const httpsAgent = new https.Agent({ rejectUnauthorized: false });
...
{ httpsAgent }
```

and make the Axios call without the `httpsAgent` option (i.e., let axios choose the default agent).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
