### PR TITLE
Fix/296 semver auto release flow

### DIFF
--- a/.github/workflows/production-back.yml
+++ b/.github/workflows/production-back.yml
@@ -1,13 +1,6 @@
 name: Backend CI/CD Workflow
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "Back/**"
-      - ".github/workflows/**"
-
   pull_request:
     branches:
       - main
@@ -26,7 +19,7 @@ jobs:
   tag-creation:
     name: 0. Automatic Creation Process of New Tags
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     outputs:
       created_tag: ${{ steps.created_tag.outputs.created_tag }}
       change_type: ${{ steps.change_type.outputs.change_type }}
@@ -37,25 +30,34 @@ jobs:
       - name: Install GitHub CLI
         run: sudo apt-get install -y gh
 
+      - name: Write PR body and log context
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "PR merged: ${{ github.event.pull_request.merged }}"
+          printf '%s' "${{ github.event.pull_request.body }}" > body.txt
+          echo "--- PR body ---"
+          cat body.txt
+          echo "--- end ---"
+
       - name: Extract type of change from PR
         id: change_type
+        if: github.event.pull_request.merged == true
         run: |
-          echo "${{ github.event.pull_request.body }}" > body.txt
-
           change_type=""
-          if grep -qi "\[x\] novo-marco" body.txt; then
+          if grep -qiE "\[x\]\s*\`?novo-marco\`?" body.txt; then
             change_type="novo-marco"
-          elif grep -qi "\[x\] nova-feature" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?nova-feature\`?" body.txt; then
             change_type="nova-feature"
-          elif grep -qi "\[x\] bug-fix" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?bug-fix\`?" body.txt; then
             change_type="bug-fix"
-          elif grep -qi "\[x\] outros" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?outros\`?" body.txt; then
             change_type="outros"
           else
-            echo "No option scheduled correctly in 'change_type:'"
+            echo "Nenhuma opção marcada corretamente no corpo do PR. Conteúdo:"
+            cat body.txt
             exit 1
           fi
-
+          echo "Tipo detectado: $change_type"
           echo "change_type=$change_type" >> "$GITHUB_OUTPUT"
 
       - name: Get the last release tag
@@ -71,23 +73,28 @@ jobs:
       - name: Calculate new tag
         id: created_tag
         run: |
-          IFS='.' read -r major minor patch <<< "${{ steps.last_tag.outputs.last_tag }}"
-          case "${{ steps.change_type.outputs.change_type }}" in
-            bug-fix|outros)
-              patch=$((patch + 1))
-              ;;
-            nova-feature)
-              minor=$((minor + 1))
-              patch=0
-              ;;
-            novo-marco)
-              major=$((major + 1))
-              minor=0
-              patch=0
-              ;;
-          esac
-          created_tag="${major}.${minor}.${patch}"
-          echo "New tag: $created_tag"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            created_tag="${{ steps.last_tag.outputs.last_tag }}"
+            echo "Dispatch manual: reutilizando tag $created_tag"
+          else
+            IFS='.' read -r major minor patch <<< "${{ steps.last_tag.outputs.last_tag }}"
+            case "${{ steps.change_type.outputs.change_type }}" in
+              bug-fix|outros)
+                patch=$((patch + 1))
+                ;;
+              nova-feature)
+                minor=$((minor + 1))
+                patch=0
+                ;;
+              novo-marco)
+                major=$((major + 1))
+                minor=0
+                patch=0
+                ;;
+            esac
+            created_tag="${major}.${minor}.${patch}"
+          fi
+          echo "Nova tag: $created_tag"
           echo "created_tag=$created_tag" >> "$GITHUB_OUTPUT"
 
   # --------------------------------------------------------------------
@@ -98,11 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: tag-creation
     env:
-      CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag || github.sha }}
-    if: >
-      always() &&
-      (needs.tag-creation.result == 'success' || needs.tag-creation.result == 'skipped') &&
-      (github.event.pull_request.merged == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag }}
+    if: needs.tag-creation.result == 'success'
     permissions:
       contents: write
       packages: write
@@ -176,7 +180,10 @@ jobs:
     name: 3. Automatic Creation Process of New Releases
     runs-on: ubuntu-latest
     needs: [tag-creation, backend-docker]
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event.pull_request.merged == true &&
+      needs.tag-creation.result == 'success' &&
+      needs.backend-docker.result == 'success'
     permissions:
       contents: write
     env:

--- a/.github/workflows/production-front.yml
+++ b/.github/workflows/production-front.yml
@@ -1,13 +1,6 @@
 name: Frontend CI/CD Workflow
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "front/**"
-      - ".github/workflows/**"
-
   pull_request:
     branches:
       - main
@@ -26,7 +19,7 @@ jobs:
   tag-creation:
     name: 0. Automatic Creation Process of New Tags
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     outputs:
       created_tag: ${{ steps.created_tag.outputs.created_tag }}
       change_type: ${{ steps.change_type.outputs.change_type }}
@@ -37,25 +30,34 @@ jobs:
       - name: Install GitHub CLI
         run: sudo apt-get install -y gh
 
+      - name: Write PR body and log context
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "PR merged: ${{ github.event.pull_request.merged }}"
+          printf '%s' "${{ github.event.pull_request.body }}" > body.txt
+          echo "--- PR body ---"
+          cat body.txt
+          echo "--- end ---"
+
       - name: Extract type of change from PR
         id: change_type
+        if: github.event.pull_request.merged == true
         run: |
-          echo "${{ github.event.pull_request.body }}" > body.txt
-
           change_type=""
-          if grep -qi "\[x\] novo-marco" body.txt; then
+          if grep -qiE "\[x\]\s*\`?novo-marco\`?" body.txt; then
             change_type="novo-marco"
-          elif grep -qi "\[x\] nova-feature" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?nova-feature\`?" body.txt; then
             change_type="nova-feature"
-          elif grep -qi "\[x\] bug-fix" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?bug-fix\`?" body.txt; then
             change_type="bug-fix"
-          elif grep -qi "\[x\] outros" body.txt; then
+          elif grep -qiE "\[x\]\s*\`?outros\`?" body.txt; then
             change_type="outros"
           else
-            echo "No option scheduled correctly in 'change_type:'"
+            echo "Nenhuma opção marcada corretamente no corpo do PR. Conteúdo:"
+            cat body.txt
             exit 1
           fi
-
+          echo "Tipo detectado: $change_type"
           echo "change_type=$change_type" >> "$GITHUB_OUTPUT"
 
       - name: Get the last release tag
@@ -71,23 +73,28 @@ jobs:
       - name: Calculate new tag
         id: created_tag
         run: |
-          IFS='.' read -r major minor patch <<< "${{ steps.last_tag.outputs.last_tag }}"
-          case "${{ steps.change_type.outputs.change_type }}" in
-            bug-fix|outros)
-              patch=$((patch + 1))
-              ;;
-            nova-feature)
-              minor=$((minor + 1))
-              patch=0
-              ;;
-            novo-marco)
-              major=$((major + 1))
-              minor=0
-              patch=0
-              ;;
-          esac
-          created_tag="${major}.${minor}.${patch}"
-          echo "New tag: $created_tag"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            created_tag="${{ steps.last_tag.outputs.last_tag }}"
+            echo "Dispatch manual: reutilizando tag $created_tag"
+          else
+            IFS='.' read -r major minor patch <<< "${{ steps.last_tag.outputs.last_tag }}"
+            case "${{ steps.change_type.outputs.change_type }}" in
+              bug-fix|outros)
+                patch=$((patch + 1))
+                ;;
+              nova-feature)
+                minor=$((minor + 1))
+                patch=0
+                ;;
+              novo-marco)
+                major=$((major + 1))
+                minor=0
+                patch=0
+                ;;
+            esac
+            created_tag="${major}.${minor}.${patch}"
+          fi
+          echo "Nova tag: $created_tag"
           echo "created_tag=$created_tag" >> "$GITHUB_OUTPUT"
 
   # --------------------------------------------------------------------
@@ -98,11 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: tag-creation
     env:
-      CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag || github.sha }}
-    if: >
-      always() &&
-      (needs.tag-creation.result == 'success' || needs.tag-creation.result == 'skipped') &&
-      (github.event.pull_request.merged == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag }}
+    if: needs.tag-creation.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -182,7 +186,12 @@ jobs:
     name: 3. Automatic Creation Process of New Releases
     runs-on: ubuntu-latest
     needs: [tag-creation, frontend-docker]
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event.pull_request.merged == true &&
+      needs.tag-creation.result == 'success' &&
+      needs.frontend-docker.result == 'success'
+    permissions:
+      contents: write
     env:
       CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag }}
       CHANGE_TYPE: ${{ needs.tag-creation.outputs.change_type }}


### PR DESCRIPTION
## Descrição

Execuções duplicadas de pipeline que estavam publicando imagens Docker com tags de hashes de commit em vez de versões SemVer após merges de PR. Causas raiz: o trigger push era acionado junto com pull_request: closed em cada merge, fazendo com que tag-creation fosse pulado (sem contexto de PR) enquanto os jobs Docker ainda executavam via always() e recorriam ao github.sha como tag da imagem. Um problema secundário causava a saída com código 1 no tag-creation com o novo formato de template de PR, pois o padrão grep não considerava as crases ao redor do rótulo do tipo de mudança.
## Tipo de mudança

<!-- Selecione EXATAMENTE UMA opção — a pipeline lê este campo para gerar a versão automaticamente -->

- [ ] `novo-marco` — mudança grande que quebra compatibilidade ou representa uma nova versão major **(X.0.0)**
- [ ] `nova-feature` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**
- [X] `bug-fix` — correção de um comportamento incorreto **(0.0.X)**
- [ ] `outros` — refatoração, ajuste de config, documentação, etc. **(0.0.X)**

## Como testar

<!-- Descreva os passos para validar as mudanças -->

1. Mergear algum pr na main
2. Validar a versão do semVer no formato v3.2.3 
3.

## Screenshots (se aplicável)

<!-- Cole prints ou GIFs da interface, se houver mudanças visuais -->

## Checklist

- [ ] Testei localmente e está funcionando
- [ ] Não quebrei nenhuma funcionalidade existente
- [X] O código está limpo e sem console.log / debug desnecessário
- [ ] Atualizei a documentação, se necessário

---

> _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
