### PR TITLE
Chore/312 replace docker scout with trivy ci image scanning

### DIFF
--- a/.github/workflows/production-front.yml
+++ b/.github/workflows/production-front.yml
@@ -160,11 +160,6 @@ jobs:
           docker tag ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:$CREATED_TAG \
                      ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:latest
 
-      - name: Push Docker images (version and latest)
-        run: |
-          docker push ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:$CREATED_TAG
-          docker push ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:latest
-
       - name: Trivy Scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -172,6 +167,11 @@ jobs:
           format: table
           exit-code: 1
           severity: CRITICAL
+
+      - name: Push Docker images (version and latest)
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:$CREATED_TAG
+          docker push ghcr.io/${{ github.repository_owner }}/horas-discentes-frontend:latest
 
   # --------------------------------------------------------------------
   # 3) RELEASE CREATION ------------------------------------------------

--- a/.github/workflows/production-front.yml
+++ b/.github/workflows/production-front.yml
@@ -110,6 +110,8 @@ jobs:
     needs: tag-creation
     env:
       CREATED_TAG: ${{ needs.tag-creation.outputs.created_tag }}
+      REGISTRY: ghcr.io
+      IMAGE_NAME: horas-discentes-frontend
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Descrição

Corrige o step do Trivy Scan no workflow de CI/CD do frontend, que apresentava dois problemas em relação ao backend: o scan era executado  após o push da imagem (permitindo que uma imagem vulnerável fosse publicada antes do gate de segurança atuar), e as variáveis de ambiente  REGISTRY e IMAGE_NAME estavam ausentes no job, fazendo o image-ref resolver de forma incorreta. Complemento as mudanças implementas por Valéria.                                           
                                                                                                    
## Tipo de mudança

<!-- Selecione EXATAMENTE UMA opção — a pipeline lê este campo para gerar a versão automaticamente -->

- [ ] `novo-marco` — mudança grande que quebra compatibilidade ou representa uma nova versão major **(X.0.0)**
- [ ] `nova-feature` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**
- [X] `bug-fix` — correção de um comportamento incorreto **(0.0.X)**
- [ ] `outros` — refatoração, ajuste de config, documentação, etc. **(0.0.X)**

## Como testar

<!-- Descreva os passos para validar as mudanças -->

1.
2.
3.

## Screenshots (se aplicável)

<!-- Cole prints ou GIFs da interface, se houver mudanças visuais -->

## Checklist

- [X] Testei localmente e está funcionando
- [X] Não quebrei nenhuma funcionalidade existente
- [X] O código está limpo e sem console.log / debug desnecessário
- [ ] Atualizei a documentação, se necessário

---

> _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
