### PR TITLE
feat: create format-dependabot-pr

### DIFF
--- a/.github/workflows/format-dependabot-pr.yml
+++ b/.github/workflows/format-dependabot-pr.yml
@@ -1,0 +1,68 @@
+name: Formatar PR do Dependabot
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  formatar-pr:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Formatar corpo do PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          BODY=$(cat <<EOF
+          ## Descrição
+
+          $PR_TITLE
+
+          ## Tipo de mudança
+
+          <!-- Selecione EXATAMENTE UMA opção — a pipeline lê este campo para gerar a versão automaticamente -->
+
+          - [ ] \`novo-marco\` — mudança grande que quebra compatibilidade ou representa uma nova versão major **(X.0.0)**
+          - [ ] \`nova-feature\` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**
+          - [ ] \`bug-fix\` — correção de um comportamento incorreto **(0.0.X)**
+          - [x] \`outros\` — refatoração, ajuste de config, documentação, etc. **(0.0.X)**
+
+          ## Como testar
+
+          <!-- Descreva os passos para validar as mudanças -->
+
+          1. Verificar se o build passa após a atualização das dependências
+          2. Confirmar que os testes automatizados continuam passando
+          3. Validar que não há breaking changes nas dependências atualizadas
+
+          ## Screenshots (se aplicável)
+
+          <!-- Cole prints ou GIFs da interface, se houver mudanças visuais -->
+
+          N/A — atualização de dependências
+
+          ## Checklist
+
+          - [x] Testei localmente e está funcionando
+          - [x] Não quebrei nenhuma funcionalidade existente
+          - [x] O código está limpo e sem console.log / debug desnecessário
+          - [x] Atualizei a documentação, se necessário
+
+          ---
+
+          > _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
+          EOF
+          )
+
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/pulls/$PR_NUMBER" \
+            -f body="$BODY"


### PR DESCRIPTION
## Descrição

Os templates defaults do github são completamente ignorados pelo dependabot, então, a cada pr que o dependabot abria ele quebrava totalmente o Actions do projeto. Solucionamos isso com um workflow que detecta se  pr foi criado pelo dependabot e preenche o boilerplate.

## Tipo de mudança

<!-- Selecione EXATAMENTE UMA opção — a pipeline lê este campo para gerar a versão automaticamente -->

- [ ] `novo-marco` — mudança grande que quebra compatibilidade ou representa uma nova versão major **(X.0.0)**
- [ ] `nova-feature` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**
- [X] `bug-fix` — correção de um comportamento incorreto **(0.0.X)**
- [ ] `outros` — refatoração, ajuste de config, documentação, etc. **(0.0.X)**

## Como testar

<!-- Descreva os passos para validar as mudanças -->

1. Mergear pr do dependabot
2.
3.

## Screenshots (se aplicável)

<!-- Cole prints ou GIFs da interface, se houver mudanças visuais -->

## Checklist

- [ ] Testei localmente e está funcionando
- [X] Não quebrei nenhuma funcionalidade existente
- [X] O código está limpo e sem console.log / debug desnecessário
- [ ] Atualizei a documentação, se necessário

---

> _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
