### PR TITLE
Fix/344 invalid domain restriction

### DIFF
--- a/Back/Back.Application/UseCases/Aluno/CreateAlunoUseCase.cs
+++ b/Back/Back.Application/UseCases/Aluno/CreateAlunoUseCase.cs
@@ -34,7 +34,8 @@ public class CreateAlunoUseCase
 
     public async Task<CreateAlunoResponse> ExecuteAsync(CreateAlunoRequest request)
     {
-        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
+        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase) &&
+            !request.Email.EndsWith(".ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException("Email institucional inválido.");
 
         // Busca a turma por ID ou Código

--- a/Back/Back.Application/UseCases/Coordenador/CriarCoordenadorUseCase.cs
+++ b/Back/Back.Application/UseCases/Coordenador/CriarCoordenadorUseCase.cs
@@ -26,7 +26,8 @@ public class CriarCoordenadorUseCase
     public async Task<CoordenadorResponse> ExecuteAsync(CadastroCoordenadorRequest request)
     {
         // 0. Validar domínio do email
-        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
+        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase) &&
+            !request.Email.EndsWith(".ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException("Email institucional inválido.");
 
         // 1. Validar o convite

--- a/Back/Back.Application/UseCases/Coordenador/EnviarConviteUseCase.cs
+++ b/Back/Back.Application/UseCases/Coordenador/EnviarConviteUseCase.cs
@@ -29,8 +29,9 @@ public class EnviarConviteUseCase
 
     public async Task ExecuteAsync(ConviteCoordenadorRequest request)
     {
-        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("Email institucional inválido. Use um endereço @ifpe.edu.br.");
+        if (!request.Email.EndsWith("@ifpe.edu.br", StringComparison.OrdinalIgnoreCase) &&
+            !request.Email.EndsWith(".ifpe.edu.br", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Email institucional inválido. Use um endereço institucional (ifpe.edu.br).");
 
         var baseUrl = _config["COORDENADOR_CONVITE_LINK"]
             ?? throw new InvalidOperationException("Variável de ambiente COORDENADOR_CONVITE_LINK não configurada.");

--- a/Back/tests/Back.Application.UnitTests/UseCases/Aluno/CreateAlunoUseCaseTests.cs
+++ b/Back/tests/Back.Application.UnitTests/UseCases/Aluno/CreateAlunoUseCaseTests.cs
@@ -67,6 +67,41 @@ public class CreateAlunoUseCaseTests
         _alunoRepo.Verify(r => r.AddAsync(It.IsAny<Back.Domain.Entities.Aluno.Aluno>()), Times.Once);
     }
 
+    [Theory]
+    [InlineData("aluno@discente.ifpe.edu.br")]
+    [InlineData("aluno@docente.ifpe.edu.br")]
+    public async Task Deve_Aceitar_Email_Com_Subdominio_Ifpe(string email)
+    {
+        var turma = new TurmaBuilder()
+            .WithId(Guid.NewGuid())
+            .WithPeriodo("2024.1")
+            .WithTurno("Noite")
+            .WithCursoId(Guid.NewGuid())
+            .Build();
+
+        _turmaRepo.Setup(r => r.GetByIdAsync(turma.Id))
+            .ReturnsAsync(turma);
+
+        _identityService.Setup(r => r.CreateUserAsync(email, "123", "ALUNO"))
+            .ReturnsAsync((true, "identity-1", Array.Empty<string>()));
+
+        _atividadeRepo.Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new List<DomainAtividade>());
+
+        var request = new CreateAlunoRequest(
+            Nome: "Aluno",
+            Email: email,
+            Matricula: "0001",
+            Senha: "123",
+            TurmaId: turma.Id
+        );
+
+        var useCase = CreateUseCase();
+        var result = await useCase.ExecuteAsync(request);
+
+        result.Email.Should().Be(email);
+    }
+
     [Fact]
     public async Task Deve_Rejeitar_Email_Nao_Institucional()
     {

--- a/Back/tests/Back.Application.UnitTests/UseCases/Coordenador/CriarCoordenadorUseCaseTests.cs
+++ b/Back/tests/Back.Application.UnitTests/UseCases/Coordenador/CriarCoordenadorUseCaseTests.cs
@@ -55,6 +55,44 @@ public class CriarCoordenadorUseCaseTests
         conviteRepo.Verify(r => r.MarcarComoUsadoAsync(convite), Times.Once);
     }
 
+    [Theory]
+    [InlineData("coordenador@discente.ifpe.edu.br")]
+    [InlineData("coordenador@docente.ifpe.edu.br")]
+    public async Task Deve_Aceitar_Email_Com_Subdominio_Ifpe(string email)
+    {
+        var conviteRepo = new Mock<IConviteCoordenadorRepository>();
+        var coordenadorRepo = new Mock<ICoordenadorRepository>();
+        var identity = new Mock<IIdentityService>();
+
+        var token = "token";
+        var cursoId = Guid.NewGuid();
+        var convite = new ConviteCoordenadorBuilder()
+            .WithId(Guid.NewGuid())
+            .WithEmail(email)
+            .WithCursoId(cursoId)
+            .WithToken(token)
+            .WithExpiracao(DateTime.UtcNow.AddHours(1))
+            .Build();
+
+        conviteRepo.Setup(r => r.GetValidByTokenAsync(token))
+            .ReturnsAsync(convite);
+        identity.Setup(i => i.CreateUserAsync(email, "Senha@123", "COORDENADOR"))
+            .ReturnsAsync((true, "user-id", Array.Empty<string>()));
+
+        var useCase = new CriarCoordenadorUseCase(
+            conviteRepo.Object,
+            coordenadorRepo.Object,
+            identity.Object);
+
+        var request = new CadastroCoordenadorRequest(
+            "Nome", "123/2025", "2025-01-01", email, "Senha@123", token);
+
+        var result = await useCase.ExecuteAsync(request);
+
+        result.Email.Should().Be(email);
+        coordenadorRepo.Verify(r => r.AddAsync(It.IsAny<CoordenadorEntity>()), Times.Once);
+    }
+
     [Fact]
     public async Task Deve_Rejeitar_Email_Docente_Legado()
     {

--- a/Back/tests/Back.Application.UnitTests/UseCases/Coordenador/EnviarConviteUseCaseTests.cs
+++ b/Back/tests/Back.Application.UnitTests/UseCases/Coordenador/EnviarConviteUseCaseTests.cs
@@ -48,6 +48,40 @@ public class EnviarConviteUseCaseTests
         conviteRepo.Verify(r => r.SaveChangesAsync(), Times.Once);
     }
 
+    [Theory]
+    [InlineData("coordenador@discente.ifpe.edu.br")]
+    [InlineData("coordenador@docente.ifpe.edu.br")]
+    public async Task Deve_Aceitar_Email_Com_Subdominio_Ifpe(string email)
+    {
+        var conviteRepo = new Mock<IConviteCoordenadorRepository>();
+        var emailService = new Mock<IEmailService>();
+        var templateService = new Mock<IEmailTemplateService>();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["COORDENADOR_CONVITE_LINK"] = "https://example.com/convite"
+            })
+            .Build();
+
+        templateService.Setup(t => t.RenderConviteCoordenador(It.IsAny<string>()))
+            .Returns("<p>convite</p>");
+
+        var useCase = new EnviarConviteUseCase(
+            conviteRepo.Object,
+            emailService.Object,
+            templateService.Object,
+            config);
+
+        var request = new ConviteCoordenadorRequest(email, Guid.NewGuid());
+
+        await useCase.ExecuteAsync(request);
+
+        emailService.Verify(s => s.EnviarEmailAsync(
+            email,
+            "Convite para cadastro de Coordenador — hora+",
+            It.IsAny<string>()), Times.Once);
+    }
+
     [Fact]
     public async Task Deve_Rejeitar_Email_Docente_Legado()
     {

--- a/front/src/app/(admin)/curso/[id]/_components/CoordinatorInviteModal.tsx
+++ b/front/src/app/(admin)/curso/[id]/_components/CoordinatorInviteModal.tsx
@@ -43,9 +43,12 @@ export const CoordinatorInviteModal = ({
   const handleCoordSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!coordEmail.endsWith('@ifpe.edu.br')) {
+    if (
+      !coordEmail.endsWith('@ifpe.edu.br') &&
+      !coordEmail.endsWith('.ifpe.edu.br')
+    ) {
       toast.error(
-        'O email do coordenador deve ser institucional (@ifpe.edu.br).'
+        'O email do coordenador deve ser institucional (ifpe.edu.br).'
       );
       return;
     }
@@ -124,11 +127,13 @@ export const CoordinatorInviteModal = ({
                       required
                       className="text-lg"
                     />
-                    {coordEmail && !coordEmail.endsWith('@ifpe.edu.br') && (
-                      <p className="text-sm text-red-500 font-medium">
-                        O email deve ser institucional (@ifpe.edu.br)
-                      </p>
-                    )}
+                    {coordEmail &&
+                      !coordEmail.endsWith('@ifpe.edu.br') &&
+                      !coordEmail.endsWith('.ifpe.edu.br') && (
+                        <p className="text-sm text-red-500 font-medium">
+                          O email deve ser institucional (ifpe.edu.br)
+                        </p>
+                      )}
                   </div>
 
                   <Button
@@ -137,7 +142,8 @@ export const CoordinatorInviteModal = ({
                     disabled={
                       isCoordLoading ||
                       !coordEmail ||
-                      !coordEmail.endsWith('@ifpe.edu.br')
+                      (!coordEmail.endsWith('@ifpe.edu.br') &&
+                        !coordEmail.endsWith('.ifpe.edu.br'))
                     }
                   >
                     {isCoordLoading ? (

--- a/front/src/components/CreateCoordinatorAccount/index.tsx
+++ b/front/src/components/CreateCoordinatorAccount/index.tsx
@@ -33,7 +33,9 @@ export const CreateCoordinatorAccount = ({
   const senha = watch('senha') || '';
 
   const isEmailValid =
-    !prefilledEmail || prefilledEmail.endsWith('@ifpe.edu.br');
+    !prefilledEmail ||
+    prefilledEmail.endsWith('@ifpe.edu.br') ||
+    prefilledEmail.endsWith('.ifpe.edu.br');
 
   return (
     <div className="min-h-screen grid md:grid-cols-2 w-full">
@@ -112,7 +114,7 @@ export const CreateCoordinatorAccount = ({
             />
             {!isEmailValid && (
               <p className="text-xs text-red-500 mt-1">
-                O email deve ser institucional (@ifpe.edu.br)
+                O email deve ser institucional (ifpe.edu.br)
               </p>
             )}
           </div>

--- a/front/src/components/FirstAccess/schemas/schema.ts
+++ b/front/src/components/FirstAccess/schemas/schema.ts
@@ -6,9 +6,11 @@ export const firstAccessSchema = z
     email: z
       .string()
       .email('Email inválido')
-      .refine((email) => email.endsWith('@ifpe.edu.br'), {
-        message: 'Use seu email institucional (@ifpe.edu.br)'
-      }),
+      .refine(
+        (email) =>
+          email.endsWith('@ifpe.edu.br') || email.endsWith('.ifpe.edu.br'),
+        { message: 'Use seu email institucional IFPE (ifpe.edu.br)' }
+      ),
     matricula: z
       .string()
       .length(13, 'A matrícula deve ter exatamente 13 caracteres')

--- a/front/src/components/LoginCard/index.tsx
+++ b/front/src/components/LoginCard/index.tsx
@@ -21,7 +21,9 @@ export const LoginCard = () => {
   const { errors } = formState;
   const emailValue = watch('email');
   const isInstitutionalEmail =
-    !!emailValue && emailValue.endsWith('@ifpe.edu.br');
+    !!emailValue &&
+    (emailValue.endsWith('@ifpe.edu.br') ||
+      emailValue.endsWith('.ifpe.edu.br'));
 
   return (
     <div className="min-h-screen grid md:grid-cols-2 w-full">
@@ -59,7 +61,7 @@ export const LoginCard = () => {
             )}
             {emailValue && !isInstitutionalEmail && (
               <p className="text-xs text-red-500 mt-1 font-medium">
-                Use seu email institucional (@ifpe.edu.br).
+                Use seu email institucional IFPE (ifpe.edu.br).
               </p>
             )}
           </div>


### PR DESCRIPTION
## Descrição

A validação de email institucional aceitava apenas endereços com domínio exato `@ifpe.edu.br`, rejeitando subdomínios como `@discente.ifpe.edu.br` e `@docente.ifpe.edu.br` — que são os emails emitidos pelo IFPE para alunos e docentes. A verificação foi ajustada para aceitar qualquer endereço cujo domínio termine em `ifpe.edu.br`, cobrindo todos os subdomínios institucionais.

## Tipo de mudança

- [x] `bug-fix` — correção de um comportamento incorreto **(0.0.X)**

## Como testar

1. Acessar a tela de **Primeiro Acesso** e informar um email `@discente.ifpe.edu.br` (ex: `mlcr1@discente.ifpe.edu.br`) — o sistema deve aceitar e prosseguir o cadastro.
2. Como admin, acessar a página de um curso e tentar enviar um convite de coordenador para um email `@docente.ifpe.edu.br` — o convite deve ser enviado sem erro.
3. Tentar cadastrar com um email externo (ex: `teste@gmail.com`) — deve continuar sendo rejeitado com a mensagem de email institucional inválido.

## Screenshots (se aplicável)

N/A — sem mudanças visuais (apenas mensagens de erro ajustadas para referenciar `ifpe.edu.br` em vez de `@ifpe.edu.br`).

## Checklist

- [x] Testei localmente e está funcionando
- [x] Não quebrei nenhuma funcionalidade existente
- [x] O código está limpo e sem console.log / debug desnecessário
- [ ] Atualizei a documentação, se necessário
