### PR TITLE
Feat/287 curricularization extension hours

### DIFF
--- a/Back/Back.Application/DTOs/Atividade/AtividadeResponse.cs
+++ b/Back/Back.Application/DTOs/Atividade/AtividadeResponse.cs
@@ -2,4 +2,4 @@
 
 namespace Back.Application.DTOs.Atividade;
 
-public record AtividadeResponse(Guid Id, string Nome, string Tipo, string Grupo, string Categoria, string CategoriaKey, int CargaMaximaSemestral, int CargaMaximaCurso);
+public record AtividadeResponse(Guid Id, string Nome, string Tipo, string Grupo, string Categoria, string CategoriaKey, int CargaMaximaSemestral, int CargaMaximaCurso, bool PossuiCurricularizacaoExtensao, int? HorasCurricularizacaoExtensao);

--- a/Back/Back.Application/DTOs/Atividade/CreateAtividadeRequest.cs
+++ b/Back/Back.Application/DTOs/Atividade/CreateAtividadeRequest.cs
@@ -11,4 +11,6 @@ public class CreateAtividadeRequest
     public int CargaMaximaSemestral { get; set; }
     public int CargaMaximaCurso { get; set; }
     public TipoAtividade Tipo { get; set; }
+    public bool PossuiCurricularizacaoExtensao { get; set; }
+    public int? HorasCurricularizacaoExtensao { get; set; }
 }

--- a/Back/Back.Application/DTOs/Atividade/UpdateAtividadeRequest.cs
+++ b/Back/Back.Application/DTOs/Atividade/UpdateAtividadeRequest.cs
@@ -33,5 +33,8 @@ namespace Back.Application.DTOs.Atividade
         [Required]
         public TipoAtividade Tipo { get; set; }
 
+        public bool PossuiCurricularizacaoExtensao { get; set; }
+
+        public int? HorasCurricularizacaoExtensao { get; set; }
     }
 }

--- a/Back/Back.Application/UseCases/Atividade/CreateAtividadeUseCase.cs
+++ b/Back/Back.Application/UseCases/Atividade/CreateAtividadeUseCase.cs
@@ -26,6 +26,12 @@ public class CreateAtividadeUseCase
 
     public async Task<Guid> ExecuteAsync(CreateAtividadeRequest request)
     {
+        var possuiCurricularizacao = request.Tipo == Back.Domain.Entities.Atividade.TipoAtividade.EXTENSAO
+            && request.PossuiCurricularizacaoExtensao;
+
+        if (possuiCurricularizacao && (request.HorasCurricularizacaoExtensao is null || request.HorasCurricularizacaoExtensao <= 0))
+            throw new ArgumentException("Informe as horas de curricularização de extensão.");
+
         var atividade = new EntidadeAtividade
         {
             Id = Guid.NewGuid(),
@@ -35,7 +41,9 @@ public class CreateAtividadeUseCase
             CategoriaKey = request.CategoriaKey,
             CargaMaximaSemestral = request.CargaMaximaSemestral,
             CargaMaximaCurso = request.CargaMaximaCurso,
-            Tipo = request.Tipo
+            Tipo = request.Tipo,
+            PossuiCurricularizacaoExtensao = possuiCurricularizacao,
+            HorasCurricularizacaoExtensao = possuiCurricularizacao ? request.HorasCurricularizacaoExtensao : null
         };
 
         await _atividadeRepo.AddAsync(atividade);

--- a/Back/Back.Application/UseCases/Atividade/GetAllAtividadesUseCase.cs
+++ b/Back/Back.Application/UseCases/Atividade/GetAllAtividadesUseCase.cs
@@ -20,7 +20,7 @@ public class GetAllAtividadesUseCase
         var atividades = await _repo.GetAllAsync();
 
         return atividades.Select(a =>
-            new AtividadeResponse(a.Id, a.Nome!, a.Tipo.ToString(), a.Grupo!, a.Categoria!, a.CategoriaKey!, a.CargaMaximaSemestral, a.CargaMaximaCurso)
+            new AtividadeResponse(a.Id, a.Nome!, a.Tipo.ToString(), a.Grupo!, a.Categoria!, a.CategoriaKey!, a.CargaMaximaSemestral, a.CargaMaximaCurso, a.PossuiCurricularizacaoExtensao, a.HorasCurricularizacaoExtensao)
         );
     }
 }

--- a/Back/Back.Application/UseCases/Atividade/UpdateAtividadeUseCase.cs
+++ b/Back/Back.Application/UseCases/Atividade/UpdateAtividadeUseCase.cs
@@ -22,6 +22,12 @@ public class UpdateAtividadeUseCase
             throw new InvalidOperationException("Atividade não encontrada.");
 
         // Atualiza as propriedades
+        var possuiCurricularizacao = request.Tipo == Back.Domain.Entities.Atividade.TipoAtividade.EXTENSAO
+            && request.PossuiCurricularizacaoExtensao;
+
+        if (possuiCurricularizacao && (request.HorasCurricularizacaoExtensao is null || request.HorasCurricularizacaoExtensao <= 0))
+            throw new ArgumentException("Informe as horas de curricularização de extensão.");
+
         atividade.Nome = request.Nome;
         atividade.Grupo = request.Grupo;
         atividade.Categoria = request.Categoria;
@@ -29,6 +35,8 @@ public class UpdateAtividadeUseCase
         atividade.CargaMaximaSemestral = request.CargaMaximaSemestral;
         atividade.CargaMaximaCurso = request.CargaMaximaCurso;
         atividade.Tipo = request.Tipo;
+        atividade.PossuiCurricularizacaoExtensao = possuiCurricularizacao;
+        atividade.HorasCurricularizacaoExtensao = possuiCurricularizacao ? request.HorasCurricularizacaoExtensao : null;
 
         await _atividadeRepo.UpdateAsync(atividade);
     }

--- a/Back/Back.Domain/Entities/Atividade/Atividade.cs
+++ b/Back/Back.Domain/Entities/Atividade/Atividade.cs
@@ -28,6 +28,10 @@ public class Atividade
 
     public string? CategoriaKey { get; set; }
 
+    public bool PossuiCurricularizacaoExtensao { get; set; }
+
+    public int? HorasCurricularizacaoExtensao { get; set; }
+
     public ICollection<AlunoAtividade.AlunoAtividade> Alunos { get; set; } = new List<AlunoAtividade.AlunoAtividade>();
 }
 

--- a/Back/Back.Domain/Entities/Atividade/AtividadeBuilder.cs
+++ b/Back/Back.Domain/Entities/Atividade/AtividadeBuilder.cs
@@ -52,5 +52,17 @@ public class AtividadeBuilder
         return this;
     }
 
+    public AtividadeBuilder WithPossuiCurricularizacaoExtensao(bool possui)
+    {
+        _atividade.PossuiCurricularizacaoExtensao = possui;
+        return this;
+    }
+
+    public AtividadeBuilder WithHorasCurricularizacaoExtensao(int? horas)
+    {
+        _atividade.HorasCurricularizacaoExtensao = horas;
+        return this;
+    }
+
     public Atividade Build() => _atividade;
 }

--- a/Back/Back.Infrastructure/Migrations/20260509175915_AddCurricularizacaoExtensaoToAtividade.Designer.cs
+++ b/Back/Back.Infrastructure/Migrations/20260509175915_AddCurricularizacaoExtensaoToAtividade.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Back.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Back.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509175915_AddCurricularizacaoExtensaoToAtividade")]
+    partial class AddCurricularizacaoExtensaoToAtividade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Back/Back.Infrastructure/Migrations/20260509175915_AddCurricularizacaoExtensaoToAtividade.cs
+++ b/Back/Back.Infrastructure/Migrations/20260509175915_AddCurricularizacaoExtensaoToAtividade.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Back.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCurricularizacaoExtensaoToAtividade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HorasCurricularizacaoExtensao",
+                table: "Atividades",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PossuiCurricularizacaoExtensao",
+                table: "Atividades",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HorasCurricularizacaoExtensao",
+                table: "Atividades");
+
+            migrationBuilder.DropColumn(
+                name: "PossuiCurricularizacaoExtensao",
+                table: "Atividades");
+        }
+    }
+}

--- a/Back/Back.Infrastructure/Persistence/Context/ApplicationDbContextFactory.cs
+++ b/Back/Back.Infrastructure/Persistence/Context/ApplicationDbContextFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Back.Infrastructure.Persistence.Context;
+
+public class ApplicationDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+{
+    public ApplicationDbContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql("Host=localhost;Database=design_time_db;Username=postgres;Password=postgres")
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/Back/tests/Back.Application.UnitTests/UseCases/Atividade/CreateAtividadeUseCaseTests.cs
+++ b/Back/tests/Back.Application.UnitTests/UseCases/Atividade/CreateAtividadeUseCaseTests.cs
@@ -16,6 +16,115 @@ namespace Back.Application.UnitTests.UseCases.Atividade;
 public class CreateAtividadeUseCaseTests
 {
     [Fact]
+    public async Task Deve_Rejeitar_Curricularizacao_Extensao_Sem_Horas()
+    {
+        var atividadeRepo = new Mock<IAtividadeRepository>();
+        var alunoRepo = new Mock<IAlunoRepository>();
+        var alunoAtividadeRepo = new Mock<IAlunoAtividadeRepository>();
+
+        alunoRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<DomainAluno>());
+
+        var request = new CreateAtividadeRequest
+        {
+            Nome = "Atividade Extensão",
+            Grupo = "G1",
+            Categoria = "CAT",
+            CategoriaKey = "CK",
+            CargaMaximaCurso = 40,
+            CargaMaximaSemestral = 10,
+            Tipo = TipoAtividade.EXTENSAO,
+            PossuiCurricularizacaoExtensao = true,
+            HorasCurricularizacaoExtensao = null
+        };
+
+        var useCase = new CreateAtividadeUseCase(
+            atividadeRepo.Object,
+            alunoRepo.Object,
+            alunoAtividadeRepo.Object
+        );
+
+        Func<Task> act = () => useCase.ExecuteAsync(request);
+
+        await act.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("Informe as horas de curricularização de extensão.");
+    }
+
+    [Fact]
+    public async Task Deve_Criar_Atividade_Extensao_Com_Curricularizacao()
+    {
+        var atividadeRepo = new Mock<IAtividadeRepository>();
+        var alunoRepo = new Mock<IAlunoRepository>();
+        var alunoAtividadeRepo = new Mock<IAlunoAtividadeRepository>();
+
+        alunoRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<DomainAluno>());
+
+        var request = new CreateAtividadeRequest
+        {
+            Nome = "Atividade Extensão",
+            Grupo = "G1",
+            Categoria = "CAT",
+            CategoriaKey = "CK",
+            CargaMaximaCurso = 40,
+            CargaMaximaSemestral = 10,
+            Tipo = TipoAtividade.EXTENSAO,
+            PossuiCurricularizacaoExtensao = true,
+            HorasCurricularizacaoExtensao = 20
+        };
+
+        var useCase = new CreateAtividadeUseCase(
+            atividadeRepo.Object,
+            alunoRepo.Object,
+            alunoAtividadeRepo.Object
+        );
+
+        var result = await useCase.ExecuteAsync(request);
+
+        result.Should().NotBe(Guid.Empty);
+        atividadeRepo.Verify(r => r.AddAsync(It.Is<DomainAtividade>(a =>
+            a.PossuiCurricularizacaoExtensao == true &&
+            a.HorasCurricularizacaoExtensao == 20
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task Nao_Deve_Aplicar_Curricularizacao_Em_Atividade_Complementar()
+    {
+        var atividadeRepo = new Mock<IAtividadeRepository>();
+        var alunoRepo = new Mock<IAlunoRepository>();
+        var alunoAtividadeRepo = new Mock<IAlunoAtividadeRepository>();
+
+        alunoRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<DomainAluno>());
+
+        var request = new CreateAtividadeRequest
+        {
+            Nome = "Atividade Complementar",
+            Grupo = "G1",
+            Categoria = "CAT",
+            CategoriaKey = "CK",
+            CargaMaximaCurso = 40,
+            CargaMaximaSemestral = 10,
+            Tipo = TipoAtividade.COMPLEMENTAR,
+            PossuiCurricularizacaoExtensao = true,
+            HorasCurricularizacaoExtensao = 20
+        };
+
+        var useCase = new CreateAtividadeUseCase(
+            atividadeRepo.Object,
+            alunoRepo.Object,
+            alunoAtividadeRepo.Object
+        );
+
+        var result = await useCase.ExecuteAsync(request);
+
+        result.Should().NotBe(Guid.Empty);
+        atividadeRepo.Verify(r => r.AddAsync(It.Is<DomainAtividade>(a =>
+            a.PossuiCurricularizacaoExtensao == false &&
+            a.HorasCurricularizacaoExtensao == null
+        )), Times.Once);
+    }
+
+    [Fact]
     public async Task Deve_Criar_Atividade_E_Gerar_AlunoAtividade()
     {
         var atividadeRepo = new Mock<IAtividadeRepository>();

--- a/front/src/components/ActivityForm/hooks/useActivityForm.ts
+++ b/front/src/components/ActivityForm/hooks/useActivityForm.ts
@@ -18,9 +18,14 @@ export function useActivityForm({ onSubmit }: Props) {
     register,
     handleSubmit,
     formState: { errors },
-    reset
+    reset,
+    watch,
+    setValue
   } = useForm<ActivityFormSchema>({
-    resolver: zodResolver(activitySchema)
+    resolver: zodResolver(activitySchema),
+    defaultValues: {
+      possuiCurricularizacaoExtensao: false
+    }
   });
 
   const handleFormSubmit = async (data: ActivityFormSchema) => {
@@ -38,6 +43,8 @@ export function useActivityForm({ onSubmit }: Props) {
     register,
     handleSubmit,
     errors,
+    watch,
+    setValue,
     handleFormSubmit
   };
 }

--- a/front/src/components/ActivityForm/index.tsx
+++ b/front/src/components/ActivityForm/index.tsx
@@ -17,9 +17,18 @@ interface Props {
   isVisible: boolean;
 }
 
-export function ActivityForm({ onSubmit, onCancel, isVisible }: Props) {
-  const { isSubmitting, register, handleSubmit, errors, handleFormSubmit } =
-    useActivityForm({ onSubmit });
+export function ActivityForm({ tipo, onSubmit, onCancel, isVisible }: Props) {
+  const {
+    isSubmitting,
+    register,
+    handleSubmit,
+    errors,
+    watch,
+    setValue,
+    handleFormSubmit
+  } = useActivityForm({ onSubmit });
+
+  const possuiCurricularizacao = watch('possuiCurricularizacaoExtensao');
 
   if (!isVisible) return null;
 
@@ -133,6 +142,71 @@ export function ActivityForm({ onSubmit, onCancel, isVisible }: Props) {
               )}
             </div>
           </div>
+
+          {tipo === 'EXTENSAO' && (
+            <div className="border-t pt-4 space-y-4">
+              <div>
+                <Label>
+                  Esta atividade possui curricularização de extensão? *
+                </Label>
+                <div className="flex gap-4 mt-2">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="curricularizacao"
+                      value="sim"
+                      checked={possuiCurricularizacao === true}
+                      onChange={() =>
+                        setValue('possuiCurricularizacaoExtensao', true, {
+                          shouldValidate: true
+                        })
+                      }
+                      className="accent-primary"
+                    />
+                    Sim
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="curricularizacao"
+                      value="nao"
+                      checked={possuiCurricularizacao === false}
+                      onChange={() => {
+                        setValue('possuiCurricularizacaoExtensao', false, {
+                          shouldValidate: true
+                        });
+                        setValue('horasCurricularizacaoExtensao', undefined);
+                      }}
+                      className="accent-primary"
+                    />
+                    Não
+                  </label>
+                </div>
+              </div>
+
+              {possuiCurricularizacao === true && (
+                <div>
+                  <Label htmlFor="horasCurricularizacaoExtensao">
+                    Horas de curricularização *
+                  </Label>
+                  <Input
+                    id="horasCurricularizacaoExtensao"
+                    type="number"
+                    min={1}
+                    {...register('horasCurricularizacaoExtensao', {
+                      valueAsNumber: true
+                    })}
+                    placeholder="Ex: 40"
+                  />
+                  {errors.horasCurricularizacaoExtensao && (
+                    <p className="text-sm text-destructive">
+                      {errors.horasCurricularizacaoExtensao.message}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
           <div className="flex gap-3 pt-4 border-t">
             <Button

--- a/front/src/components/ActivityForm/schemas/schema.ts
+++ b/front/src/components/ActivityForm/schemas/schema.ts
@@ -1,21 +1,40 @@
 import * as z from 'zod';
 
-export const activitySchema = z.object({
-  nome: z
-    .string()
-    .min(1, 'Nome é obrigatório')
-    .min(3, 'Nome deve ter pelo menos 3 caracteres'),
-  grupo: z.string().min(1, 'Grupo é obrigatório'),
-  categoria: z.string().min(1, 'Categoria é obrigatória'),
-  categoriaKey: z.string().min(1, 'Área é obrigatória'),
-  cargaMaximaSemestral: z
-    .number({ message: 'Carga semestral deve ser um número' })
-    .positive('Deve ser maior que zero')
-    .max(200, 'Máximo de 200 horas'),
-  cargaMaximaCurso: z
-    .number({ message: 'Carga do curso deve ser um número' })
-    .positive('Deve ser maior que zero')
-    .max(500, 'Máximo de 500 horas')
-});
+export const activitySchema = z
+  .object({
+    nome: z
+      .string()
+      .min(1, 'Nome é obrigatório')
+      .min(3, 'Nome deve ter pelo menos 3 caracteres'),
+    grupo: z.string().min(1, 'Grupo é obrigatório'),
+    categoria: z.string().min(1, 'Categoria é obrigatória'),
+    categoriaKey: z.string().min(1, 'Área é obrigatória'),
+    cargaMaximaSemestral: z
+      .number({ message: 'Carga semestral deve ser um número' })
+      .positive('Deve ser maior que zero')
+      .max(200, 'Máximo de 200 horas'),
+    cargaMaximaCurso: z
+      .number({ message: 'Carga do curso deve ser um número' })
+      .positive('Deve ser maior que zero')
+      .max(500, 'Máximo de 500 horas'),
+    possuiCurricularizacaoExtensao: z.boolean().optional(),
+    horasCurricularizacaoExtensao: z
+      .number()
+      .int()
+      .positive('Deve ser maior que zero')
+      .optional()
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.possuiCurricularizacaoExtensao === true &&
+      !data.horasCurricularizacaoExtensao
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Informe as horas de curricularização.',
+        path: ['horasCurricularizacaoExtensao']
+      });
+    }
+  });
 
 export type ActivityFormSchema = z.infer<typeof activitySchema>;

--- a/front/src/services/activityService.ts
+++ b/front/src/services/activityService.ts
@@ -9,6 +9,8 @@ export interface AtividadeResponse {
   categoriaKey: string;
   cargaMaximaSemestral: number;
   cargaMaximaCurso: number;
+  possuiCurricularizacaoExtensao: boolean;
+  horasCurricularizacaoExtensao?: number;
 }
 
 export interface CreateAtividadeRequest {
@@ -19,6 +21,8 @@ export interface CreateAtividadeRequest {
   cargaMaximaSemestral: number;
   cargaMaximaCurso: number;
   tipo: number; // 0 for EXTENSAO, 1 for COMPLEMENTAR
+  possuiCurricularizacaoExtensao?: boolean | undefined;
+  horasCurricularizacaoExtensao?: number | undefined;
 }
 
 export const listarAtividades = async (): Promise<AtividadeResponse[]> => {


### PR DESCRIPTION
## Descrição

Implementa o campo de curricularização de extensão no cadastro de atividades. Ao criar uma atividade do tipo **Extensão**, o coordenador agora é perguntado se a atividade possui curricularização de extensão (sim/não). Ao marcar **sim**, um campo numérico obrigatório de horas é exibido. A informação é validada no frontend e no backend, persistida no banco e retornada na listagem de atividades. Atividades do tipo Complementar não são afetadas.

## Tipo de mudança

- [x] `nova-feature` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**

## Como testar

1. Acessar o painel de coordenador → **Cadastro de Atividades** → aba **Extensão** → clicar em **Adicionar Atividade**
2. Verificar que a seção *"Esta atividade possui curricularização de extensão?"* aparece com opções Sim/Não
3. Selecionar **Sim** e confirmar que o campo *"Horas de curricularização"* aparece; tentar salvar sem preencher e verificar mensagem de erro de validação
4. Preencher as horas e salvar — a atividade deve ser criada com sucesso
5. Selecionar **Não** e salvar — a atividade deve ser criada sem o campo de horas
6. Trocar para a aba **Complementares**, adicionar uma atividade e verificar que a seção de curricularização **não aparece**

## Screenshots (se aplicável)

N/A

## Checklist

- [x] Testei localmente e está funcionando
- [x] Não quebrei nenhuma funcionalidade existente
- [x] O código está limpo e sem console.log / debug desnecessário
- [ ] Atualizei a documentação, se necessário

> _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
