### PR TITLE
Feat/369 limitar caracteres especificacao

### DIFF
--- a/back/Back.Application/DTOs/Certificado/CreateCertificadoRequest.cs
+++ b/back/Back.Application/DTOs/Certificado/CreateCertificadoRequest.cs
@@ -37,6 +37,7 @@ public class CreateCertificadoRequest
     [Required]
     public int TotalPeriodos { get; set; }
 
+    [StringLength(500, ErrorMessage = "A especificação da atividade deve ter no máximo 500 caracteres.")]
     public string? Descricao { get; set; }
 
     [Required]

--- a/back/Back.Application/DTOs/Certificado/UpdateCertificadoRequest.cs
+++ b/back/Back.Application/DTOs/Certificado/UpdateCertificadoRequest.cs
@@ -39,6 +39,7 @@ namespace Back.Application.DTOs.Certificado
         [Required]
         public int TotalPeriodos { get; set; }
 
+        [StringLength(500, ErrorMessage = "A especificação da atividade deve ter no máximo 500 caracteres.")]
         public string? Descricao { get; set; }
 
         [Required]

--- a/front/src/components/HoursRegistrationForm/index.tsx
+++ b/front/src/components/HoursRegistrationForm/index.tsx
@@ -17,6 +17,7 @@ import SelectBox from '@components/ui/SelectBox';
 import { AtividadeResponse } from '@/services/activityService';
 
 import { useHoursRegistrationForm } from './hooks/useHoursRegistrationForm';
+import { ESPECIFICACAO_MAX_LENGTH } from './schemas/hoursRegistrationFormSchema';
 
 interface HoursRegistrationFormProps {
   categoriasComplementares: AtividadeResponse[];
@@ -49,6 +50,9 @@ export default function HoursRegistrationForm({
 
   const { register } = formMethods;
   const [termosExpandidos, setTermosExpandidos] = React.useState(false);
+
+  const especificacaoLength =
+    formMethods.watch('especificacaoAtividade')?.length ?? 0;
 
   const categoriasAtuais =
     tipoRegistro === 'horas-extensao'
@@ -314,15 +318,23 @@ export default function HoursRegistrationForm({
             <textarea
               id="especificacaoAtividade"
               {...register('especificacaoAtividade')}
+              maxLength={ESPECIFICACAO_MAX_LENGTH}
               className={`${inputClass} h-24`}
               rows={3}
               placeholder="Descreva brevemente a atividade realizada, local e período."
             />
-            {errors.especificacaoAtividade && (
-              <p className={errorClass}>
-                {errors.especificacaoAtividade.message}
-              </p>
-            )}
+            <div className="flex justify-between items-start gap-2 mt-1">
+              <div className="flex-1">
+                {errors.especificacaoAtividade && (
+                  <p className={errorClass}>
+                    {errors.especificacaoAtividade.message}
+                  </p>
+                )}
+              </div>
+              <span className="text-xs text-gray-500 whitespace-nowrap">
+                {especificacaoLength}/{ESPECIFICACAO_MAX_LENGTH}
+              </span>
+            </div>
           </div>
 
           <div className="col-span-1 md:col-span-3">

--- a/front/src/components/HoursRegistrationForm/schemas/hoursRegistrationFormSchema.ts
+++ b/front/src/components/HoursRegistrationForm/schemas/hoursRegistrationFormSchema.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 // Mensagem de erro padrão para campos obrigatórios
 const requiredError = (fieldName: string) => `${fieldName} é obrigatório(a).`;
 
+// Limite de caracteres para a especificação da atividade
+export const ESPECIFICACAO_MAX_LENGTH = 500;
+
 // Schema para o arquivo (comprovante)
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ACCEPTED_FILE_TYPES = [
@@ -25,7 +28,11 @@ export const hoursRegistrationFormSchema = z
       .min(3, 'O local deve ter pelo menos 3 caracteres.'),
     especificacaoAtividade: z
       .string(requiredError('Especificação das Atividades'))
-      .min(10, 'A descrição deve ter pelo menos 10 caracteres.'),
+      .min(10, 'A descrição deve ter pelo menos 10 caracteres.')
+      .max(
+        ESPECIFICACAO_MAX_LENGTH,
+        `A descrição deve ter no máximo ${ESPECIFICACAO_MAX_LENGTH} caracteres.`
+      ),
     categoria: z
       .string(requiredError('Categoria'))
       .min(1, 'Selecione uma categoria.'),


### PR DESCRIPTION
## Descrição

Adiciona validação para que o usuário não consiga digitar 1 milhão de caracteres e quebrar a aplicação.

## Tipo de mudança

<!-- Selecione EXATAMENTE UMA opção — a pipeline lê este campo para gerar a versão automaticamente -->

- [ ] `novo-marco` — mudança grande que quebra compatibilidade ou representa uma nova versão major **(X.0.0)**
- [ ] `nova-feature` — nova funcionalidade ou melhoria sem quebrar o que já existe **(0.X.0)**
- [X] `bug-fix` — correção de um comportamento incorreto **(0.0.X)**
- [ ] `outros` — refatoração, ajuste de config, documentação, etc. **(0.0.X)**

## Como testar

<!-- Descreva os passos para validar as mudanças -->

1.
2.
3.

## Screenshots (se aplicável)

<!-- Cole prints ou GIFs da interface, se houver mudanças visuais -->

## Checklist

- [X] Testei localmente e está funcionando
- [X] Não quebrei nenhuma funcionalidade existente
- [X] O código está limpo e sem console.log / debug desnecessário
- [X] Atualizei a documentação, se necessário

---

> _Este template é lido automaticamente pela pipeline de CI/CD. Certifique-se de marcar **apenas uma** opção no tipo de mudança._
